### PR TITLE
Fix twig version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"slim/slim" : "2.*",
 		"slim/views": "0.*",
 		"slimcontroller/slimcontroller": "dev-master",
-        "twig/twig": "1.*",
+		"twig/twig": "1.36.0",
 		"j4mie/idiorm" : "*",
 		"monolog/monolog": "1.*",
 		"swiftmailer/swiftmailer" : "dev-master",


### PR DESCRIPTION
Since [version 1.37.0 of Twig](https://github.com/twigphp/Twig/commits/v1.37.0) they dropped support for PHP 5.3